### PR TITLE
Begin documenting the View object

### DIFF
--- a/_docs/native-depictions.md
+++ b/_docs/native-depictions.md
@@ -53,4 +53,110 @@ Sileo depictions are composed of tabs, which contain an array of views. Views ca
 
 ### View object
 
-TODO: Document this and classes. SO. MUCH. EFFORT.
+A tab is made up of multiple views, allowing repos to customize how their information is displayed on screen. There are multiple different kinds of views, each dictated by a different class.
+
+Each view will define the `class` key, with the remaining keys required being determined by what class is used.
+
+#### Headers
+
+Class: `DepictionHeaderView`
+
+Creates a large title intended for separating major sections of a given tab.
+
+| Key       | Type                                  | Description                    | Required?
+|-----------|---------------------------------------|--------------------------------|----------------|
+| `title` | String | The title of the header.           | Yes
+| `useBottomMargin` | Boolean | Adds a margin below the header. | No
+
+#### Subheaders
+
+Class: `DepictionSubheaderView`
+
+Subheaders are smaller headers.
+
+| Key       | Type                                  | Description                    | Required?
+|-----------|---------------------------------------|--------------------------------|----------------|
+| `title` | String | The title of the header. | Yes
+| `useBottomMargin` | Boolean | Adds a margin below the header. | No
+| `useBoldText` | Boolean | Make the text bold. | No
+
+#### Markdown Text
+
+Class: `DepictionMarkdownView`
+
+Allows for basic Markdown or HTML to be displayed, ideal for large blocks of text.
+
+| Key       | Type                                  | Description                    | Required?
+|-----------|---------------------------------------|--------------------------------|----------------|
+| `markdown` | String | The text to be rendered as Markdown (or HTML)           | Yes
+| `useSpacing` | Boolean | Enable or disable the use of spacing.           | No
+| `useRawFormat` | Boolean | If true, `markdown` will accept basic HTML instead of Markdown. | No
+
+#### Screenshots
+
+Class: `DepictionScreenshotsView`
+
+Displays a screenshot carousel with provided images.
+
+| Key       | Type                                  | Description                    | Required?
+|-----------|---------------------------------------|--------------------------------|----------------|
+| `screenshots` | [Array of Screenshot objects](#screenshot-object) | The screenshots to be used. | Yes
+| `itemCornerRadius` | Integer | Change the roundness of the view's corners.           | No
+| `itemSize` | Dimensions (`{x,y}`) | Change the size of the view. | No
+
+##### Screenshot Object
+
+Screenshot objects just store a URL to an image and accessibility text to suppliment it.
+
+| Key       | Type                                  | Description
+|-----------|---------------------------------------|--------------------------------|----------------|
+| `url` | String (URL) | A URL to the screenshot.
+| `accessibilityText` | String | Text to be interpreted by accessibility features like VoiceOver.
+
+#### Table Text
+
+Class: `DepictionTableTextView`
+
+Adds a table cell with a given value that is ideal for displaying the current version or release date of a tweak.
+
+| Key       | Type                                     | Description    | Required?
+|-----------|---------------------------------------|-------------------|----------------|
+| `title` | String | The title of the row. | Yes
+| `text` | String | The text to be displayed next to the title. | Yes
+
+#### Table Button
+
+Class: `DepictionTableButtonView`
+
+Adds a table cell that opens a given URL when tapped.
+
+| Key       | Type                                     | Description    | Required?
+|-----------|---------------------------------------|-------------------|----------------|
+| `title` | String | The button's label. | Yes
+| `action` | String (URL) | The URL to open when the button is pressed. | Yes
+
+#### Separator
+
+Class: `DepictionSeparatorView`
+
+Displays a separator.
+
+#### Spacer
+
+Class: `DepictionSpacerView`
+
+Adds a space of variable height.
+
+| Key       | Type                                     | Description    | Required?
+|-----------|---------------------------------------|-------------------|----------------|
+| `spacing` | Integer | How high the spacer should be. | Yes
+
+#### AdMob Integration
+
+Class: `DepictionAdmobView`
+
+Adds an [AdMob](https://admob.google.com/home/) banner to the depiction if you wish to display an advertisement.
+
+| Key       | Type                                     | Description    | Required?
+|-----------|---------------------------------------|-------------------|----------------|
+| `adUnitID` | String | Your Ad Unit ID provided by Google. | Yes

--- a/_docs/native-depictions.md
+++ b/_docs/native-depictions.md
@@ -32,7 +32,7 @@ Sileo depictions are composed of tabs, which contain an array of views. Views ca
 
 ### Root object
 
-<!-- TODO: Get AB to style tables :/ Spacing also seems slighly off. -->
+<!-- TODO: Get AB to style tables properly. -->
 
 | Key           | Type                                  | Description                                                                             |
 |---------------|---------------------------------------|-----------------------------------------------------------------------------------------|

--- a/_docs/native-depictions.md
+++ b/_docs/native-depictions.md
@@ -112,11 +112,11 @@ Displays a screenshot carousel with provided images.
 
 Screenshot objects just store a URL to an image and accessibility text to suppliment it.
 
-| Key       | Type                                  | Description
+| Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
-| `url` | String (URL) | A URL to the screenshot.
-| `accessibilityText` | String | Text to be interpreted by accessibility features like VoiceOver.
-| `video` | Boolean | Sets whether the URL is a video rather than an image
+| `url` | String (URL) | A URL to the screenshot. | Yes
+| `accessibilityText` | String | Text to be interpreted by accessibility features like VoiceOver. | Yes
+| `video` | Boolean | Sets whether the URL is a video rather than an image | No
 
 #### Table Text
 

--- a/_docs/native-depictions.md
+++ b/_docs/native-depictions.md
@@ -66,7 +66,9 @@ Creates a large title intended for separating major sections of a given tab.
 | Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `title` | String | The title of the header.           | Yes
-| `useBottomMargin` | Boolean | Adds a margin below the header. | No
+| `useMargins` | Boolean | Allow margins above/below the header. | No
+| `useBottomMargin` | Boolean | Adds a margin below the header (does nothing if useMargins = false). | No
+| `useBoldText` | Boolean | Make the text bold. | No
 
 #### Subheaders
 
@@ -77,7 +79,8 @@ Subheaders are smaller headers.
 | Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `title` | String | The title of the header. | Yes
-| `useBottomMargin` | Boolean | Adds a margin below the header. | No
+| `useMargins` | Boolean | Allow margins above/below the header. | No
+| `useBottomMargin` | Boolean | Adds a margin below the header (does nothing if useMargins = false). | No
 | `useBoldText` | Boolean | Make the text bold. | No
 
 #### Markdown Text
@@ -89,7 +92,8 @@ Allows for basic Markdown or HTML to be displayed, ideal for large blocks of tex
 | Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `markdown` | String | The text to be rendered as Markdown (or HTML)           | Yes
-| `useSpacing` | Boolean | Enable or disable the use of spacing.           | No
+| `useSpacing` | Boolean | Enable or disable the use of vertical spacing.           | No
+| `useMargins` | Boolean | Enable or disable the use of horizontal margins.           | No
 | `useRawFormat` | Boolean | If true, `markdown` will accept basic HTML instead of Markdown. | No
 
 #### Screenshots
@@ -101,7 +105,7 @@ Displays a screenshot carousel with provided images.
 | Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `screenshots` | [Array of Screenshot objects](#screenshot-object) | The screenshots to be used. | Yes
-| `itemCornerRadius` | Integer | Change the roundness of the view's corners.           | No
+| `itemCornerRadius` | Double | Change the roundness of the view's corners.           | No
 | `itemSize` | Dimensions (`{x,y}`) | Change the size of the view. | No
 
 ##### Screenshot Object
@@ -112,6 +116,7 @@ Screenshot objects just store a URL to an image and accessibility text to suppli
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `url` | String (URL) | A URL to the screenshot.
 | `accessibilityText` | String | Text to be interpreted by accessibility features like VoiceOver.
+| `video` | Boolean | Sets whether the URL is a video rather than an image
 
 #### Table Text
 
@@ -134,6 +139,9 @@ Adds a table cell that opens a given URL when tapped.
 |-----------|---------------------------------------|-------------------|----------------|
 | `title` | String | The button's label. | Yes
 | `action` | String (URL) | The URL to open when the button is pressed. | Yes
+| `backupAction` | String (URL) | An alternate action to try if the action is not supported. | No
+| `yPadding` | Double | Padding to put above and below the button. | No
+| `openExternal` | Double | Set whether to open the URL in an external app. | No
 
 #### Separator
 
@@ -149,7 +157,7 @@ Adds a space of variable height.
 
 | Key       | Type                                     | Description    | Required?
 |-----------|---------------------------------------|-------------------|----------------|
-| `spacing` | Integer | How high the spacer should be. | Yes
+| `spacing` | Double | How high the spacer should be. | Yes
 
 #### AdMob Integration
 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -18,3 +18,12 @@
     color: #aaa;
     margin: 0 4px;
 }
+
+table {
+    border-collapse: separate;
+    border-spacing: 9px;
+}
+
+h4 {
+    margin-top: 7px;
+}


### PR DESCRIPTION
This PR includes documentation the following classes, all which relate to the View object:
- DepictionHeaderView
- DepictionSubheaderView
- DepictionScreenshotsView
- DepictionTableTextView
- DepictionTableButtonView
- DepictionSeparatorView
- DepictionSpacerView
- DepictionAdmobView

I also fixed some table/header spacing, which I noticed was an issue.

I recommend that you look over the changes and make sure everything is accurate. The documentation was written with information gathered from others' implementations, so there may be unused classes or keys for documented classes that I didn't document.

If you want any images attached, please send screenshots and I'll add them where appropriate. I am not jailbroken, so I do not have Sileo installed.

*Note: everything has been tested and the site properly compiles on Jekyll.*