### PR TITLE
Fix falsehood in the label depictions.

### DIFF
--- a/_docs/native-depictions.md
+++ b/_docs/native-depictions.md
@@ -117,7 +117,7 @@ Labels are highly-customizable snippets of text with a customizable color.
 | Key       | Type                                  | Description                    | Required?
 |-----------|---------------------------------------|--------------------------------|----------------|
 | `text` | String | The text to be displayed next to the title. | Yes
-| `margins` | MarginsEnum | Changes the position of the element. Either is `top`, `left`, `bottom`, or `right`. | No
+| `margins` | UIEdgeInsets | Adds margins around the element. Formatted `{top, left, bottom, right}`. | No
 | `useMargins` | Boolean | Allow margins above/below the header. | No
 | `usePadding` | Boolean | Add a slight margin to the top and bottom of a label. | No
 | `fontWeight` | String | The "weight" of the text. | No


### PR DESCRIPTION
Fixes taken from [this file](https://github.com/Sileo/Sileo/blob/8086977d796ad528953975346e4a8e3698b8b4c0/Sileo/UI/PackageViewController/DepictionView/DepictionLabelView/DepictionLabelView.swift#L15) in the Swift rewrite and noticed in the Packix depictions.

I don't know why it was initially worded as an enum (probably misunderstanding on my part), but this resolves this error.